### PR TITLE
QA#1 - Ensure verification emails are sent after registration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,10 @@ WORKDIR /myapp
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     libpq-dev \
-    && apt-get install -y libc-bin=2.36-9+deb12u7 \
+    libc-bin \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
 
 # Install Python dependencies in /.venv
 COPY requirements.txt .
@@ -30,7 +31,7 @@ RUN python -m venv /.venv \
 FROM python:3.12-slim-bookworm as final
 
 # Upgrade libc-bin in the final stage to ensure security patch is applied
-RUN apt-get update && apt-get install -y libc-bin=2.36-9+deb12u7 \
+RUN apt-get update && apt-get install -y libc-bin \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -190,3 +190,28 @@ async def test_list_users_unauthorized(async_client, user_token):
         headers={"Authorization": f"Bearer {user_token}"}
     )
     assert response.status_code == 403  # Forbidden, as expected for regular user
+
+import pytest
+
+@pytest.mark.asyncio
+async def test_registration_triggers_email(mocker, async_client):
+    # Mock the email service method to prevent real email sending
+    mock_send_email = mocker.patch("app.services.email_service.EmailService.send_verification_email")
+
+    user_data = {
+        "email": "test_email_trigger@example.com",
+        "nickname": "triggernick",
+        "first_name": "Trigger",
+        "last_name": "Test",
+        "bio": "Testing email trigger",
+        "profile_picture_url": "https://example.com/trigger.jpg",
+        "linkedin_profile_url": "https://linkedin.com/in/trigger",
+        "github_profile_url": "https://github.com/trigger",
+        "role": "ANONYMOUS",
+        "password": "SecurePass123!"
+    }
+
+    response = await async_client.post("/register/", json=user_data)
+
+    assert response.status_code in [200, 201]
+    mock_send_email.assert_called_once()


### PR DESCRIPTION
This PR resolves an issue where verification emails were not being sent after user registration. The underlying cause was a missing users table due to unapplied Alembic migrations, which led to internal server errors and email logic silently failing. After applying the migrations and confirming correct .env configuration, the system successfully delivered a verification email via MailTrap for non-admin users.

Closes: #1 

Additionally, added a test (test_registration_triggers_email) to verify that verification emails are triggered for new non-admin users.


<img width="1022" alt="Screenshot 2025-05-09 at 1 23 11 AM" src="https://github.com/user-attachments/assets/24507c51-2c5c-4587-bc92-81e0d3fbdd1d" />
