### PR TITLE
QA#3 Enforce password rules and add tests to validate strength

### DIFF
--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -33,9 +33,27 @@ class UserBase(BaseModel):
     class Config:
         from_attributes = True
 
+from pydantic import field_validator
+
 class UserCreate(UserBase):
     email: EmailStr = Field(..., example="john.doe@example.com")
     password: str = Field(..., example="Secure*1234")
+
+    @field_validator("password")
+    @classmethod
+    def validate_password(cls, v):
+        if len(v) < 8:
+            raise ValueError("Password must be at least 8 characters long")
+        if not re.search(r"[A-Z]", v):
+            raise ValueError("Password must include at least one uppercase letter")
+        if not re.search(r"[a-z]", v):
+            raise ValueError("Password must include at least one lowercase letter")
+        if not re.search(r"\d", v):
+            raise ValueError("Password must include at least one number")
+        if not re.search(r"[!@#$%^&*()_+=\-{}[\]:\";'<>?,./]", v):
+            raise ValueError("Password must include at least one special character")
+        return v
+
 
 class UserUpdate(UserBase):
     email: Optional[EmailStr] = Field(None, example="john.doe@example.com")

--- a/tests/test_api/test_password_validation.py
+++ b/tests/test_api/test_password_validation.py
@@ -1,0 +1,43 @@
+import pytest
+
+@pytest.mark.asyncio
+async def test_register_fails_with_short_password(async_client):
+    user_data = {
+        "email": "shortpass@example.com",
+        "nickname": "shorty",
+        "first_name": "Test",
+        "last_name": "User",
+        "role": "ANONYMOUS",
+        "password": "Short1!"
+    }
+    response = await async_client.post("/register/", json=user_data)
+    assert response.status_code == 422
+    assert "Password must be at least 8 characters long" in response.text
+
+@pytest.mark.asyncio
+async def test_register_fails_missing_special_char(async_client):
+    user_data = {
+        "email": "nospecial@example.com",
+        "nickname": "nospecial",
+        "first_name": "Test",
+        "last_name": "User",
+        "role": "ANONYMOUS",
+        "password": "ValidPass123"
+    }
+    response = await async_client.post("/register/", json=user_data)
+    assert response.status_code == 422
+    assert "Password must include at least one special character" in response.text
+
+@pytest.mark.asyncio
+async def test_register_success_with_strong_password(async_client):
+    user_data = {
+        "email": "strong@example.com",
+        "nickname": "strongnick",
+        "first_name": "Test",
+        "last_name": "User",
+        "role": "ANONYMOUS",
+        "password": "StrongPass#123"
+    }
+    response = await async_client.post("/register/", json=user_data)
+    assert response.status_code in [200, 201]
+    assert response.json()["email"] == "strong@example.com"


### PR DESCRIPTION
This PR addresses QA Issue #3 by implementing password strength validation in the UserCreate schema. It enforces minimum password length and complexity (uppercase, lowercase, digit, special character) to enhance security.

I have also added 3 new tests:

Fails if password is too short
Fails if password is missing special characters
Succeeds with a strong password

Closes #3

before: 
<img width="1259" alt="Screenshot 2025-05-09 at 2 22 12 AM" src="https://github.com/user-attachments/assets/f2430593-4dd2-4d9f-a85e-79a8d916550e" />

After: 
<img width="1316" alt="Screenshot 2025-05-09 at 2 24 24 AM" src="https://github.com/user-attachments/assets/a59af6f0-baad-479c-9962-2582c62ccbcc" />
